### PR TITLE
Fix: Corrects SQL join condition in backlinks API

### DIFF
--- a/api/backlinks.php
+++ b/api/backlinks.php
@@ -39,7 +39,7 @@ try {
             FROM
                 notes n
             JOIN
-                pages p ON n.page_id = p.page_id
+                pages p ON n.page_id = p.id
             WHERE
                 n.content LIKE :searchTerm
 


### PR DESCRIPTION
The `api/backlinks.php` script was producing a 500 error due to an incorrect SQL query. The query attempted to join the `notes` table with the `pages` table using `pages.page_id` (`ON n.page_id = p.page_id`).

However, the `pages` table schema defines its primary key as `id`, not `page_id`. This commit corrects the join condition to use `pages.id` (`ON n.page_id = p.id`), resolving the database error.

I verified the fix by checking PHP syntax and by executing the script against a test SQLite database, which confirmed the query now runs correctly and produces the expected results.