### PR TITLE
feat: Implement improved file uploading and attachment handling

### DIFF
--- a/api/attachment.php
+++ b/api/attachment.php
@@ -38,7 +38,7 @@ try {
         }
 
         // Create dated subfolder
-        $dateFolder = date('Y/m');
+        $dateFolder = date('Y-m-d');
         $targetDir = $uploadsDir . '/' . $dateFolder;
         if (!file_exists($targetDir)) {
             mkdir($targetDir, 0777, true);

--- a/css/style.css
+++ b/css/style.css
@@ -563,11 +563,27 @@ a.property-tag:hover {
 }
 .attachment-actions button:hover { opacity: 1; color: var(--accent-color); }
 .attachment-preview { margin-top: 6px; width: 100%; }
-.attachment-preview img, .attachment-preview video, .attachment-preview audio {
-    max-width: 100%; border-radius: var(--radius-sm); display: block;
+.attachment-preview video,
+.attachment-preview audio {
+    max-width: 100%; /* Ensure they don't overflow their container */
+    height: auto;    /* Maintain aspect ratio for video */
+    display: block;
+    margin-top: 5px;
+    border-radius: var(--radius-sm);
 }
-.attachment-preview img { border: 1px solid var(--border-color); object-fit: cover; max-height: 120px; }
-.attachment-preview audio { width: 100%; }
+.attachment-preview audio {
+    width: 100%; /* Ensure audio player takes full width of its container */
+}
+.attachment-image { /* This class is on the img tag directly if it's an image attachment */
+    cursor: pointer;
+    max-width: 200px; /* Constrain preview size */
+    max-height: 150px;
+    border: 1px solid #ddd;
+    margin-top: 5px;
+    border-radius: var(--radius-sm);
+    display: block; /* Ensure it behaves as a block for margin and sizing */
+    object-fit: cover; /* Ensure the image covers the area without distortion */
+}
 .outline-content .attachment.broken { background: #fff0f0; border-color: #e74c3c; color: #e74c3c; }
 .outline-content .attachment.broken:hover { background: #ffe0e0; border-color: #c0392b; color: #c0392b; }
 
@@ -746,4 +762,17 @@ a.block-ref-link:hover {
 .suggestion-item.highlighted {
     background-color: var(--accent-color, #3182ce);
     color: white;
+}
+
+/* Drag and Drop File Upload Styles */
+#outline-container.drag-over {
+  /* General indication on the whole container */
+  border: 2px dashed var(--accent-color);
+  background-color: rgba(49, 130, 206, 0.05); /* Subtle blue from accent */
+}
+
+.outline-item.drag-over-item > .outline-content {
+  /* Indication on the specific item being hovered over */
+  background-color: rgba(49, 130, 206, 0.15); /* Slightly more prominent blue */
+  box-shadow: 0 0 0 2px var(--accent-color) inset; /* Inner border to highlight */
 }

--- a/js/app.js
+++ b/js/app.js
@@ -898,6 +898,13 @@ function editNote(id, currentContentText) {
     textarea.addEventListener('input', handleSnippetReplacement);
     textarea.addEventListener('input', handleAutoCloseBrackets);
 
+    // Add paste event listener for handling image pastes
+    textarea.addEventListener('paste', (event) => {
+        if (typeof window.handlePastedImage === 'function') {
+            window.handlePastedImage(event, id); // 'id' is the noteId in editNote
+        }
+    });
+
     // Link autosuggestion event listeners (same as in createNote)
     textarea.addEventListener('input', (event) => {
         const currentTextarea = event.target;
@@ -1404,3 +1411,44 @@ function handleSnippetReplacement(event) {
 
     }, 0);
 }
+
+// --- Drag and Drop File Upload Handler ---
+// Attached to window for now, assuming no ES6 modules for simplicity.
+window.handleDroppedFiles = async function(noteId, files) {
+    if (!files || files.length === 0) {
+        return;
+    }
+
+    let allUploadsSuccessful = true;
+    // Use a for...of loop to allow await within the loop
+    for (const file of files) {
+        try {
+            // uploadFileAPI is defined in js/api.js and should return a promise.
+            // It typically handles creating FormData and making the fetch request.
+            await uploadFileAPI(noteId, file);
+            console.log(`File ${file.name} uploaded successfully to note ${noteId}`);
+        } catch (error) {
+            allUploadsSuccessful = false;
+            console.error('Error uploading file:', file.name, error);
+            alert(`Error uploading file: ${file.name}\n${error.message || 'Unknown error'}`);
+            // Continue to try uploading other files even if one fails.
+        }
+    }
+
+    // Refresh the page to show new attachments, regardless of individual failures,
+    // so successful uploads are displayed.
+    // This matches the behavior of the single file upload via button.
+    if (currentPage && currentPage.id) {
+        navigateToPage(currentPage.id);
+    } else {
+        console.warn("Current page context lost after file drop. Cannot auto-refresh.");
+        // If all uploads were intended to be successful before refresh, this alert might change.
+        // But since we refresh even on partial success, this specific alert might only be relevant
+        // if currentPage.id is truly lost for other reasons.
+        if (allUploadsSuccessful) {
+             alert("File(s) uploaded, but couldn't automatically refresh the page. Please refresh manually.");
+        } else {
+             alert("Some files uploaded, but couldn't automatically refresh. Please refresh manually to see changes.");
+        }
+    }
+};

--- a/js/render.js
+++ b/js/render.js
@@ -194,10 +194,10 @@ async function renderNoteContent(note, prefetchedBlocks = {}) {
             // Determine icon and preview based on file type
             if (['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(fileExtension)) {
                 icon = '🖼️'; 
-                previewHtml = `<img src="uploads/${attachment.filename}" class="attachment-image" alt="${attachment.original_name}">`;
+                previewHtml = `<img src="uploads/${attachment.filename}" class="attachment-image" alt="${attachment.original_name}" onclick="event.stopPropagation(); showImageModal(this.src, this.alt);">`;
             } else if (['mp4', 'webm', 'mov'].includes(fileExtension)) {
                 icon = '🎥'; 
-                previewHtml = `<div class="attachment-preview"><video src="uploads/${attachment.filename}" controls></video></div>`;
+                previewHtml = `<div class="attachment-preview"><video src="uploads/${attachment.filename}" controls width="100%"></video></div>`;
             } else if (['mp3', 'wav', 'ogg'].includes(fileExtension)) {
                 icon = '🎵'; 
                 previewHtml = `<div class="attachment-preview"><audio src="uploads/${attachment.filename}" controls></audio></div>`;

--- a/js/ui.js
+++ b/js/ui.js
@@ -143,6 +143,156 @@ function setActiveBlock(element, scrollIntoView = true) {
     }
 }
 
+// --- Paste Image Handling ---
+window.handlePastedImage = async function(event, noteId) {
+    if (!noteId) {
+        // This case should ideally be prevented by only adding the listener for existing notes,
+        // but as a safeguard:
+        // console.warn("handlePastedImage called without a noteId. Pasting images is only supported for existing notes being edited.");
+        // alert("Pasting images is only supported for existing notes that are being edited.");
+        // Allowing paste to proceed normally if no noteId (e.g. for new notes not yet saved)
+        return;
+    }
+
+    const items = (event.clipboardData || event.originalEvent.clipboardData).items;
+    let imageFile = null;
+
+    for (const item of items) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+            imageFile = item.getAsFile();
+            break; // Handle first image found
+        }
+    }
+
+    if (!imageFile) {
+        return; // No image file found in paste items, let default paste action proceed.
+    }
+
+    event.preventDefault(); // Prevent default paste action (e.g., inserting raw file path or base64)
+
+    // Optional: give the file a more descriptive name (server will still make it unique)
+    // The server (api/image.php) generates a unique name, so client-side name is mostly for local reference.
+    const extension = imageFile.type.split('/')[1] || 'png'; // Get extension from MIME type
+    const tempFilename = `pasted_image_${Date.now()}.${extension}`;
+
+    try {
+        // uploadFileAPI is expected to be in js/api.js
+        // It should return a promise with { success: true, filename: "YYYY-MM-DD/unique_name.ext", ... }
+        // The third argument (tempFilename) is passed to uploadFileAPI, which in turn passes it to api/image.php
+        // if api/image.php is modified to use it as 'original_name' or part of its naming logic.
+        // Current uploadFileAPI calls api/image.php which doesn't use the client's suggested filename for storage path,
+        // but it might use it for the 'original_name' DB field.
+        const responseData = await uploadFileAPI(noteId, imageFile, tempFilename); 
+
+        if (!responseData || !responseData.success || !responseData.filename) {
+            console.error("Upload response missing success flag or filename.", responseData);
+            throw new Error("Upload response did not include a filename or indicate success.");
+        }
+        
+        // responseData.filename is expected to be "YYYY-MM-DD/unique_server_generated_name.ext"
+        const imageMarkdown = `![Pasted Image](uploads/${responseData.filename})`;
+        
+        const textarea = event.target;
+        // const start = textarea.selectionStart;
+        // const end = textarea.selectionEnd;
+        
+        // Use document.execCommand for inserting text to support undo/redo and better cursor handling.
+        if (!document.execCommand("insertText", false, imageMarkdown)) {
+            // Fallback if execCommand fails or is not supported for some reason (though unlikely for 'insertText')
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            textarea.value = textarea.value.substring(0, start) + imageMarkdown + textarea.value.substring(end);
+            textarea.selectionStart = textarea.selectionEnd = start + imageMarkdown.length;
+        }
+
+        // Trigger input event for any frameworks/listeners that depend on it
+        textarea.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+
+        console.log(`Image pasted and uploaded as ${responseData.filename} to note ${noteId}`);
+        // The image markdown is now in the textarea. The user needs to save the note
+        // for this change to persist and for the image to be rendered on next load.
+
+    } catch (error) {
+        console.error('Error uploading pasted image:', error);
+        alert(`Error uploading pasted image: ${error.message || 'Unknown error'}`);
+    }
+};
+
+// --- Drag and Drop File Upload Logic ---
+if (outlineContainer) {
+    outlineContainer.addEventListener('dragover', (event) => {
+        event.preventDefault();
+        // Check if items being dragged are files
+        if (event.dataTransfer.types.includes('Files')) {
+            // Check if the drag is over a valid drop target (an outline item or the container itself if empty)
+            const potentialTarget = event.target.closest('.outline-item');
+            if (potentialTarget || outlineContainer.children.length === 0 || event.target === outlineContainer) {
+                 outlineContainer.classList.add('drag-over');
+            } else {
+                // If dragging over gaps between items, don't show global drag-over
+                outlineContainer.classList.remove('drag-over');
+            }
+            // Optionally, add class to specific item being hovered over
+            if(potentialTarget) {
+                potentialTarget.classList.add('drag-over-item');
+            }
+        }
+    });
+
+    outlineContainer.addEventListener('dragleave', (event) => {
+        // Remove global drag-over indicator
+        outlineContainer.classList.remove('drag-over');
+        // Remove specific item drag-over indicator
+        const potentialTarget = event.target.closest('.outline-item');
+        if (potentialTarget) {
+            potentialTarget.classList.remove('drag-over-item');
+        }
+        // More robust check if leaving the container or entering a child that is not a drop target
+        if (!outlineContainer.contains(event.relatedTarget) || event.relatedTarget === null) {
+             outlineContainer.classList.remove('drag-over');
+        }
+        // Clean up any item-specific highlights if we truly left the container
+        const highlightedItems = outlineContainer.querySelectorAll('.drag-over-item');
+        highlightedItems.forEach(item => item.classList.remove('drag-over-item'));
+    });
+
+    outlineContainer.addEventListener('drop', async (event) => {
+        event.preventDefault();
+        outlineContainer.classList.remove('drag-over');
+        const highlightedItems = outlineContainer.querySelectorAll('.drag-over-item');
+        highlightedItems.forEach(item => item.classList.remove('drag-over-item'));
+
+        const files = event.dataTransfer.files;
+        if (files.length === 0) {
+            return;
+        }
+
+        let targetNoteElement = null;
+        // Attempt to find the specific outline item the drop occurred on
+        let droppedOnItem = event.target.closest('.outline-item');
+
+        if (droppedOnItem) {
+            targetNoteElement = droppedOnItem;
+        } else if (activeBlockElement && activeBlockElement.matches('.outline-item')) {
+            // Fallback to the globally active block element if the drop was not on a specific item
+            // but an item is active.
+            targetNoteElement = activeBlockElement;
+        }
+
+        if (targetNoteElement && targetNoteElement.dataset.noteId) {
+            const noteId = targetNoteElement.dataset.noteId;
+            if (typeof window.handleDroppedFiles === 'function') {
+                window.handleDroppedFiles(noteId, files);
+            } else {
+                console.error('handleDroppedFiles function is not available.');
+                alert('File drop handling is not properly configured.');
+            }
+        } else {
+            alert('Please select a specific note block or drop directly onto a note block to attach files.');
+        }
+    });
+}
+
 // --- Modal and Direct UI Interaction Functions ---
 
 /**


### PR DESCRIPTION
This commit introduces several enhancements to file uploading and attachment management:

- Server-side:
    - Uploaded files (general attachments and images) are now stored in date-specific subfolders (`uploads/YYYY-MM-DD/`).
    - `api/attachment.php` and `api/image.php` updated accordingly.

- Client-side:
    - Drag-and-drop: You can now drag files directly onto note blocks to upload them as attachments.
    - Paste images: Images can be pasted directly into the note editor for existing notes, which uploads them and embeds markdown.
    - Attachment rendering:
        - Audio files are rendered with an `<audio>` player.
        - Video files are rendered with a `<video>` player (width 100%). - Attached images are now clickable and expand into a modal view.
    - Associated UI and styling changes for drag-over feedback and attachment presentation.