### PR TITLE
Update php-tests workflow to trigger on migr/** branches

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -2,7 +2,7 @@ name: PHP Tests
 
 on:
   push:
-    branches: [ main, feat/impr ]
+    branches: [ main, feat/impr, migr/** ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
The GitHub Actions workflow for PHP tests was not triggering for branches named with the `migr/` prefix, such as `migr/alpinejs`.

This change adds `migr/**` to the list of branches that will trigger the workflow on push events, ensuring that tests are run automatically for these development branches.