### PR TITLE
Fix: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -2,7 +2,7 @@ name: PHP Tests
 
 on:
   push:
-    branches: [ main, feat/impr ]
+    branches: [ main, feat/impr, migr/** ]
   pull_request:
     branches: [ main ]
 
@@ -57,7 +57,7 @@ jobs:
         name: codecov-umbrella
 
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results-${{ matrix.php-version }}-${{ matrix.test-suite }}


### PR DESCRIPTION
The previous commit to update workflow triggers introduced a deprecation error because `actions/upload-artifact@v3` is no longer supported.

This commit updates the action to `actions/upload-artifact@v4` to resolve the error and ensure the workflow runs correctly.