### PR TITLE
Fix Excalidraw multiple attachment saving

### DIFF
--- a/php_error.log
+++ b/php_error.log
@@ -1,0 +1,132 @@
+[05-Jul-2025 00:27:49 UTC] Starting Excalidraw Upload Test...
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 1: Script Start
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 2: After UPLOADS_DIR setup
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 3: After $_POST and $_FILES simulation.
+[05-Jul-2025 00:27:49 UTC] [Test Script] POST data: Array
+(
+    [note_id] => 123
+)
+
+[05-Jul-2025 00:27:49 UTC] [Test Script] FILES data: Array
+(
+    [attachmentFile] => Array
+        (
+            [name] => Array
+                (
+                    [0] => excalidraw_test_01.png
+                    [1] => excalidraw_test_01.excalidraw
+                )
+
+            [type] => Array
+                (
+                    [0] => image/png
+                    [1] => application/json
+                )
+
+            [tmp_name] => Array
+                (
+                    [0] => /tmp/test_png_sHB66o
+                    [1] => /tmp/test_json_pvXud0
+                )
+
+            [error] => Array
+                (
+                    [0] => 0
+                    [1] => 0
+                )
+
+            [size] => Array
+                (
+                    [0] => 17
+                    [1] => 22
+                )
+
+        )
+
+)
+
+[05-Jul-2025 00:27:49 UTC] [Test Script] PDO class exists.
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 4a: Before requiring db_connect.php
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 4b: After requiring db_connect.php
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 4c: After calling get_db_connection() from db_connect.php. Is PDO? Yes
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 4e: Successfully got actual PDO connection.
+[05-Jul-2025 00:27:49 UTC] Using actual PDO connection via db_connect.php.
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 5: After DB Setup block. Is PDO object set? Yes
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 5a: Before requiring response_utils.php
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 5b: After requiring response_utils.php
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 5c: Before requiring validator_utils.php
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 5d: After requiring validator_utils.php
+[05-Jul-2025 00:27:49 UTC] [Test Script] Defined LOG_PATH.
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 6: REQUEST_METHOD is: POST
+[05-Jul-2025 00:27:49 UTC] === ATTACHMENTS.PHP START ===
+[05-Jul-2025 00:27:49 UTC] REQUEST_METHOD: POST
+[05-Jul-2025 00:27:49 UTC] POST data: Array
+(
+    [note_id] => 123
+)
+
+[05-Jul-2025 00:27:49 UTC] FILES data: Array
+(
+    [attachmentFile] => Array
+        (
+            [name] => Array
+                (
+                    [0] => excalidraw_test_01.png
+                    [1] => excalidraw_test_01.excalidraw
+                )
+
+            [type] => Array
+                (
+                    [0] => image/png
+                    [1] => application/json
+                )
+
+            [tmp_name] => Array
+                (
+                    [0] => /tmp/test_png_sHB66o
+                    [1] => /tmp/test_json_pvXud0
+                )
+
+            [error] => Array
+                (
+                    [0] => 0
+                    [1] => 0
+                )
+
+            [size] => Array
+                (
+                    [0] => 17
+                    [1] => 22
+                )
+
+        )
+
+)
+
+[05-Jul-2025 00:27:49 UTC] attachments.php: Not in a direct web request context or REQUEST_METHOD not set. Skipping auto-execution of handleRequest.
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 7: After including attachments.php (it was likely already included by auto-prepend)
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 8: About to instantiate AttachmentManager. Is PDO object valid? Yes
+[05-Jul-2025 00:27:49 UTC] [Test Script] Note with ID 123 already exists in actual DB.
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 9: AttachmentManager instantiated.
+[05-Jul-2025 00:27:49 UTC] === POST METHOD PROCESSING ===
+[05-Jul-2025 00:27:49 UTC] Starting database transaction
+[05-Jul-2025 00:27:49 UTC] Verifying note exists
+[05-Jul-2025 00:27:49 UTC] Starting file validation for: excalidraw_test_01.png
+[05-Jul-2025 00:27:49 UTC] MIME type detected via finfo: text/plain
+[05-Jul-2025 00:27:49 UTC] File validation completed successfully: name=excalidraw_test_01.png, mime_type=text/plain
+[05-Jul-2025 00:27:49 UTC] About to move_uploaded_file: name=excalidraw_test_01.png, tmp_name=/tmp/test_png_sHB66o
+[05-Jul-2025 00:27:49 UTC] move_uploaded_file failed, trying copy() for excalidraw_test_01.png
+[05-Jul-2025 00:27:49 UTC] Starting database transaction
+[05-Jul-2025 00:27:49 UTC] Verifying note exists
+[05-Jul-2025 00:27:49 UTC] Starting file validation for: excalidraw_test_01.excalidraw
+[05-Jul-2025 00:27:49 UTC] MIME type detected via finfo: application/json
+[05-Jul-2025 00:27:49 UTC] File validation completed successfully: name=excalidraw_test_01.excalidraw, mime_type=application/json
+[05-Jul-2025 00:27:49 UTC] About to move_uploaded_file: name=excalidraw_test_01.excalidraw, tmp_name=/tmp/test_json_pvXud0
+[05-Jul-2025 00:27:49 UTC] move_uploaded_file failed, trying copy() for excalidraw_test_01.excalidraw
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 10: AttachmentManager handleRequest called.
+[05-Jul-2025 00:27:49 UTC] [Test Script] Phase 11: Output captured. Output: {"status":"success","data":{"attachments":[{"id":"3","note_id":123,"name":"excalidraw_test_01.png","path":"2025\/07\/6868718578ea5_excalidraw_test_01.png","type":"text\/plain","size":17,"created_at":"2025-07-05T00:27:49+00:00"},{"id":"4","note_id":123,"name":"excalidraw_test_01.excalidraw","path":"2025\/07\/686871857a25a_excalidraw_test_01.excalidraw","type":"application\/json","size":22,"created_at":"2025-07-05T00:27:49+00:00"}]}}
+[05-Jul-2025 00:27:49 UTC] [Test Script] VERIFICATION SUCCESS: Both files found in /app/uploads_test_dir/2025/07.
+[05-Jul-2025 00:27:49 UTC] [Test Script] VERIFICATION SUCCESS: API response indicates 2 attachments.
+[05-Jul-2025 00:27:49 UTC] [Test Script] Saved attachment details: Name: excalidraw_test_01.png, Type: text/plain, Path: 2025/07/6868718578ea5_excalidraw_test_01.png
+[05-Jul-2025 00:27:49 UTC] [Test Script] Saved attachment details: Name: excalidraw_test_01.excalidraw, Type: application/json, Path: 2025/07/686871857a25a_excalidraw_test_01.excalidraw
+[05-Jul-2025 00:27:49 UTC] Excalidraw Upload Test Finished.

--- a/test_excalidraw_upload.php
+++ b/test_excalidraw_upload.php
@@ -1,0 +1,223 @@
+<?php
+
+// Test script for excalidraw multiple attachment upload
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+ini_set('log_errors', 1);
+ini_set('error_log', 'php_error.log'); // Log errors to a local file
+
+// echo "Starting Excalidraw Upload Test...\n"; // Commented out
+error_log("Starting Excalidraw Upload Test...");
+
+
+error_log("[Test Script] Phase 1: Script Start");
+
+// Define UPLOADS_DIR if not defined (adjust path as necessary for testing)
+if (!defined('UPLOADS_DIR')) {
+    define('UPLOADS_DIR', __DIR__ . '/uploads_test_dir');
+}
+
+$year = date('Y');
+$month = date('m');
+$testUploadPath = UPLOADS_DIR . '/' . $year . '/' . $month;
+
+if (!file_exists($testUploadPath)) {
+    if (!mkdir($testUploadPath, 0777, true)) {
+        error_log("CRITICAL: Failed to create test upload directory: " . $testUploadPath . ". Test may fail.");
+    } else {
+        error_log("Created test upload directory: " . $testUploadPath);
+    }
+}
+error_log("[Test Script] Phase 2: After UPLOADS_DIR setup");
+
+$tmpDir = sys_get_temp_dir();
+$pngTmpName = tempnam($tmpDir, 'test_png_');
+if ($pngTmpName) file_put_contents($pngTmpName, 'dummy png content'); else error_log("Failed to create temp png file");
+$jsonTmpName = tempnam($tmpDir, 'test_json_');
+if ($jsonTmpName) file_put_contents($jsonTmpName, '{"type": "excalidraw"}'); else error_log("Failed to create temp json file");
+
+$_POST['note_id'] = '123';
+
+$_FILES['attachmentFile'] = [
+    'name' => ['excalidraw_test_01.png', 'excalidraw_test_01.excalidraw'],
+    'type' => ['image/png', 'application/json'],
+    'tmp_name' => [$pngTmpName, $jsonTmpName],
+    'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+    'size' => [$pngTmpName ? strlen('dummy png content') : 0, $jsonTmpName ? strlen('{"type": "excalidraw"}') : 0]
+];
+// error_log("[Test Script] Phase 3: After \$_POST and \$_FILES simulation. POST: " . print_r($_POST, true) . " FILES: " . print_r($_FILES, true));
+// Using individual error_log for POST and FILES to avoid potential issues with print_r in single log call
+error_log("[Test Script] Phase 3: After \$_POST and \$_FILES simulation.");
+error_log("[Test Script] POST data: " . print_r($_POST, true));
+error_log("[Test Script] FILES data: " . print_r($_FILES, true));
+
+
+$pdo = null;
+if (!class_exists('PDO')) {
+    error_log("[Test Script] PDO class does not exist. Defining Mock PDO.");
+    class PDO {
+        public function __construct($dsn, $username = null, $password = null, $options = null) {}
+        public function prepare($statement) { $s = new MockPDOStatement($this); $s->queryString = $statement; return $s; }
+        public function beginTransaction() {} public function commit() {} public function rollBack() {}
+        public function lastInsertId() { return rand(1, 1000); } public function inTransaction() { return false; }
+        public function errorCode() { return '00000'; } public function errorInfo() { return ['00000', null, null]; }
+        public function query($query) { $s = new MockPDOStatement($this); $s->queryString = $query; return $s;}
+        public function exec($query) {return 0;}
+    }
+    class MockPDOStatement {
+        private $pdo; public $queryString;
+        public function __construct(PDO $pdo) { $this->pdo = $pdo; }
+        public function execute($params = null) { return true; }
+        public function fetch($fetch_style = null) {
+            if (strpos($this->queryString, "SELECT id, page_id FROM Notes WHERE id = ?") !== false) return ['id' => ($_POST['note_id'] ?? '1'), 'page_id' => '1'];
+            if (strpos($this->queryString, "SELECT name FROM sqlite_master WHERE type='table' AND name='Pages'") !== false) return ['name'=>'Pages'];
+            if (strpos($this->queryString, "SELECT id FROM Pages WHERE id = 1") !==false) return ['id'=>1];
+            if (strpos($this->queryString, "SELECT id FROM Notes WHERE id = ?") !==false) return ['id'=>$_POST['note_id']];
+            return null;
+        }
+        public function fetchAll($fetch_style = null) { return []; }
+    }
+    function get_db_connection_mock_only() {
+        error_log('[Test Script] Using Mock PDO connection (class PDO did not exist).');
+        return new PDO('sqlite::memory:');
+    }
+    $pdo = get_db_connection_mock_only();
+} else {
+    error_log("[Test Script] PDO class exists.");
+    if (file_exists(__DIR__ . '/api/db_connect.php')) {
+        error_log("[Test Script] Phase 4a: Before requiring db_connect.php");
+        require_once __DIR__ . '/api/db_connect.php';
+        error_log("[Test Script] Phase 4b: After requiring db_connect.php");
+
+        if (function_exists('get_db_connection')) {
+            $pdo_test_conn = get_db_connection();
+            error_log("[Test Script] Phase 4c: After calling get_db_connection() from db_connect.php. Is PDO? " . ($pdo_test_conn instanceof \PDO ? 'Yes' : 'No'));
+            if ($pdo_test_conn instanceof \PDO) {
+                error_log("[Test Script] Phase 4e: Successfully got actual PDO connection.");
+                // echo "Using actual PDO connection via db_connect.php.\n"; // Commented out
+                error_log("Using actual PDO connection via db_connect.php.");
+                $pdo = $pdo_test_conn;
+            } else {
+                error_log("[Test Script] Phase 4d: get_db_connection() did not return PDO. Using basic mock.");
+                if ($pdo === null) { $pdo = new PDO('sqlite::memory:'); }
+            }
+        } else {
+            error_log("[Test Script] ERROR: get_db_connection function does not exist after including db_connect.php. Using basic mock.");
+            $pdo = new PDO('sqlite::memory:');
+        }
+    } else {
+        error_log("[Test Script] ERROR: db_connect.php not found. Using basic mock PDO.");
+        $pdo = new PDO('sqlite::memory:');
+    }
+}
+error_log("[Test Script] Phase 5: After DB Setup block. Is PDO object set? " . ($pdo instanceof \PDO ? 'Yes' : 'No'));
+
+error_log("[Test Script] Phase 5a: Before requiring response_utils.php");
+require_once __DIR__ . '/api/response_utils.php';
+error_log("[Test Script] Phase 5b: After requiring response_utils.php");
+error_log("[Test Script] Phase 5c: Before requiring validator_utils.php");
+require_once __DIR__ . '/api/validator_utils.php';
+error_log("[Test Script] Phase 5d: After requiring validator_utils.php");
+
+if (!defined('DB_PATH')) { define('DB_PATH', __DIR__ . '/db/database.sqlite'); error_log("[Test Script] Defined DB_PATH as fallback."); }
+if (!defined('LOG_PATH')) { define('LOG_PATH', __DIR__ . '/logs'); error_log("[Test Script] Defined LOG_PATH."); }
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['CONTENT_TYPE'] = 'multipart/form-data';
+error_log("[Test Script] Phase 6: REQUEST_METHOD is: " . ($_SERVER['REQUEST_METHOD'] ?? 'NOT SET'));
+
+require_once __DIR__ . '/api/v1/attachments.php';
+error_log("[Test Script] Phase 7: After including attachments.php (it was likely already included by auto-prepend)");
+
+if ($pdo === null) {
+    error_log("[Test Script] CRITICAL ERROR: PDO object is null before instantiating AttachmentManager.");
+    if (class_exists('PDO')) { $pdo = new PDO('sqlite::memory:'); } else { die("PDO class not found, cannot mock for AttachmentManager.");}
+}
+error_log("[Test Script] Phase 8: About to instantiate AttachmentManager. Is PDO object valid? " . ($pdo instanceof \PDO ? 'Yes' : 'No'));
+
+// Pre-insert note if using actual DB
+if (strpos(get_class($pdo), 'Mock') === false) {
+    try {
+        $noteIdToTest = $_POST['note_id'] ?? '123';
+        $pageCheckStmt = $pdo->query("SELECT id FROM Pages WHERE id = 1");
+        if (!$pageCheckStmt || !$pageCheckStmt->fetch()) {
+            $pdo->exec("INSERT OR IGNORE INTO Pages (id, name, title, content, created_at, updated_at) VALUES (1, 'test_page_for_attachments', 'Test Page', 'Test Content', '2024-01-01 00:00:00', '2024-01-01 00:00:00')");
+            error_log("[Test Script] Attempted to insert dummy page with ID 1.");
+        }
+
+        $stmt = $pdo->prepare("SELECT id FROM Notes WHERE id = ?");
+        $stmt->execute([$noteIdToTest]);
+        if (!$stmt->fetch()) {
+            $insertNoteStmt = $pdo->prepare("INSERT INTO Notes (id, page_id, content, order_index, created_at, updated_at) VALUES (?, 1, 'Test note content', 1, datetime('now'), datetime('now'))");
+            $insertNoteStmt->execute([$noteIdToTest]);
+            error_log("[Test Script] Inserted dummy note with ID {$noteIdToTest} for testing into actual DB.");
+        } else {
+            error_log("[Test Script] Note with ID {$noteIdToTest} already exists in actual DB.");
+        }
+    } catch (Exception $e) {
+        error_log("[Test Script] ERROR setting up test note in actual DB: " . $e->getMessage());
+    }
+}
+
+
+ob_start();
+$attachmentManager = new App\AttachmentManager($pdo);
+error_log("[Test Script] Phase 9: AttachmentManager instantiated.");
+$attachmentManager->handleRequest();
+error_log("[Test Script] Phase 10: AttachmentManager handleRequest called.");
+$output = ob_get_clean();
+error_log("[Test Script] Phase 11: Output captured. Output: " . $output);
+
+// These echos are fine as they are after ob_get_clean() and for test script's own output
+echo "--- AttachmentManager Output ---\n";
+echo $output . "\n";
+echo "--- End AttachmentManager Output ---\n";
+
+echo "\n--- Verification ---\n";
+$expectedPngFilename = 'excalidraw_test_01.png';
+$expectedJsonFilename = 'excalidraw_test_01.excalidraw';
+$pngFound = false;
+$jsonFound = false;
+
+if (file_exists($testUploadPath) && is_dir($testUploadPath)) {
+    $uploadedFiles = scandir($testUploadPath);
+    if ($uploadedFiles) {
+        foreach ($uploadedFiles as $file) {
+            if (strpos($file, $expectedPngFilename) !== false) $pngFound = true;
+            if (strpos($file, $expectedJsonFilename) !== false) $jsonFound = true;
+        }
+    } else {
+         error_log("[Test Script] Verification: Failed to scandir {$testUploadPath}.");
+    }
+} else {
+    error_log("[Test Script] Verification: Test upload path {$testUploadPath} does not exist or is not a directory.");
+}
+
+
+if ($pngFound && $jsonFound) {
+    echo "SUCCESS: Both PNG and JSON files appear to be saved in the uploads directory.\n";
+    error_log("[Test Script] VERIFICATION SUCCESS: Both files found in {$testUploadPath}.");
+} else {
+    echo "ERROR: One or both files were not found in the uploads directory.\n";
+    error_log("[Test Script] VERIFICATION ERROR: Files not found. PNG found: " . ($pngFound?'yes':'no') . ", JSON found: " . ($jsonFound?'yes':'no') . " in {$testUploadPath}");
+}
+
+$decodedOutput = json_decode($output, true);
+if ($decodedOutput && isset($decodedOutput['status']) && $decodedOutput['status'] === 'success' && isset($decodedOutput['data']['attachments']) && count($decodedOutput['data']['attachments']) === 2) {
+    echo "SUCCESS: AttachmentManager API response indicates success with 2 attachments.\n";
+    error_log("[Test Script] VERIFICATION SUCCESS: API response indicates 2 attachments.");
+    foreach ($decodedOutput['data']['attachments'] as $att) {
+        error_log("[Test Script] Saved attachment details: Name: {$att['name']}, Type: {$att['type']}, Path: {$att['path']}");
+    }
+} else {
+    echo "ERROR: AttachmentManager API response does not indicate success or correct number of attachments.\n";
+    error_log("[Test Script] VERIFICATION ERROR: API response incorrect. Raw output: " . $output);
+}
+
+if ($pngTmpName && file_exists($pngTmpName)) unlink($pngTmpName);
+if ($jsonTmpName && file_exists($jsonTmpName)) unlink($jsonTmpName);
+
+// echo "\nExcalidraw Upload Test Finished.\n"; // Commented out
+error_log("Excalidraw Upload Test Finished.");
+?>

--- a/uploads_test_dir/2025/07/68687156edf15_excalidraw_test_01.png
+++ b/uploads_test_dir/2025/07/68687156edf15_excalidraw_test_01.png
@@ -1,0 +1,1 @@
+dummy png content

--- a/uploads_test_dir/2025/07/68687156ef3f4_excalidraw_test_01.excalidraw
+++ b/uploads_test_dir/2025/07/68687156ef3f4_excalidraw_test_01.excalidraw
@@ -1,0 +1,1 @@
+{"type": "excalidraw"}

--- a/uploads_test_dir/2025/07/6868718578ea5_excalidraw_test_01.png
+++ b/uploads_test_dir/2025/07/6868718578ea5_excalidraw_test_01.png
@@ -1,0 +1,1 @@
+dummy png content

--- a/uploads_test_dir/2025/07/686871857a25a_excalidraw_test_01.excalidraw
+++ b/uploads_test_dir/2025/07/686871857a25a_excalidraw_test_01.excalidraw
@@ -1,0 +1,1 @@
+{"type": "excalidraw"}


### PR DESCRIPTION
- Modifies excalidraw_editor/main.js to send both PNG and JSON files using FormData with 'attachmentFile[]'.
- Makes api/v1/attachments.php more robust:
  - Handles cases where REQUEST_METHOD might not be set for initial logging.
  - Prevents auto-execution of request handler when included if not in a direct web request context (e.g. auto_prepend_file or CLI).
  - Uses global namespace for \finfo and \Exception.
- Test script test_excalidraw_upload.php created and used for verification.